### PR TITLE
Increases dpi for tesseract extraction of pdfs

### DIFF
--- a/textract/parsers/pdf_parser.py
+++ b/textract/parsers/pdf_parser.py
@@ -54,7 +54,7 @@ class Parser(ShellParser):
         base = os.path.join(temp_dir, 'conv')
         contents = []
         try:
-            stdout, _ = self.run(['pdftoppm', filename, base])
+            stdout, _ = self.run(['pdftoppm', '-r', '300', filename, base])
 
             for page in sorted(os.listdir(temp_dir)):
                 page_path = os.path.join(temp_dir, page)


### PR DESCRIPTION
Tesseract recommends a minimum dpi of 300 (https://github.com/tesseract-ocr/tesseract/wiki/ImproveQuality#rescaling) and the default pdftoppm dpi is 150. I experienced poor accuracy on some documents and increasing the dpi fixed the issue. This could be controllable by a keyword argument, but the tesseract recommended setting seems like a better default. Love this package, it's a lifesaver.